### PR TITLE
make and, or, xor, add - variadic (#12)

### DIFF
--- a/include/circt/Dialect/RTL/Combinatorial.td
+++ b/include/circt/Dialect/RTL/Combinatorial.td
@@ -63,15 +63,39 @@ class UTBinRTLOp<string mnemonic, list<OpTrait> traits = []> :
   }];
 }
 
+// Base class for variadic operators.
+class VariadicRTLOp<string mnemonic, list<OpTrait> traits = []> :
+      RTLOp<mnemonic, !listconcat(traits, [NoSideEffect])> {
+  let arguments = (ins Variadic<AnySignlessInteger>:$operands);
+  let results = (outs AnySignlessInteger:$result);
+
+  let assemblyFormat = [{
+    $operands  attr-dict `:` functional-type($operands, results)
+  }];
+}
+
+class UTVariadicRTLOp<string mnemonic, list<OpTrait> traits = []> :
+      VariadicRTLOp<mnemonic,
+               !listconcat(traits,
+                           [SameTypeOperands, SameOperandsAndResultType])> {
+   let assemblyFormat = [{
+    $operands  attr-dict `:` type($result)
+  }];
+}
+
 // Arithmetic and Logical Binary Operations.
 def AddOp : UTBinRTLOp<"add", [Commutative]>;
 def SubOp : UTBinRTLOp<"sub">;
 def MulOp : UTBinRTLOp<"mul", [Commutative]>;
 def DivOp : UTBinRTLOp<"div">;
 def ModOp : UTBinRTLOp<"mod">;
-def AndOp : UTBinRTLOp<"and", [Commutative]>;
-def OrOp  : UTBinRTLOp<"or",  [Commutative]>;
-def XorOp : UTBinRTLOp<"xor", [Commutative]>;
+
+def AndOp : UTVariadicRTLOp<"and", [Commutative]>;
+def OrOp  : UTVariadicRTLOp<"or", [Commutative]>;
+def XorOp : UTVariadicRTLOp<"xor", [Commutative]>;
+
+// Concatenate a variadic list of operands together.
+def ConcatOp : VariadicRTLOp<"concat">;
 
 //===----------------------------------------------------------------------===//
 // Unary Operations
@@ -124,14 +148,3 @@ def ZExtOp : RTLOp<"zext", [NoSideEffect]> {
 }
 
 // TODO: Bit extract range, use it for trunc.
-
-def ConcatOp : RTLOp<"concat", [NoSideEffect]> {
-  let summary = "Concatenate a variadic list of operands together.";
-
-  let arguments = (ins Variadic<AnySignlessInteger>:$inputs);
-  let results = (outs AnySignlessInteger:$result);
-
-  let assemblyFormat = [{
-    $inputs attr-dict `:` functional-type($inputs, results)
-  }];
-}

--- a/include/circt/Dialect/RTL/Visitors.h
+++ b/include/circt/Dialect/RTL/Visitors.h
@@ -23,7 +23,9 @@ public:
     return TypeSwitch<Operation *, ResultType>(op)
         .template Case<ConstantOp,
                        // Arithmetic and Logical Binary Operations.
-                       AddOp, SubOp, MulOp, DivOp, ModOp, AndOp, OrOp, XorOp,
+                       AddOp, SubOp, MulOp, DivOp, ModOp,
+                       // Bitwise operations
+                       AndOp, OrOp, XorOp,
                        // Reduction Operators
                        AndROp, OrROp, XorROp,
                        // Other operations.
@@ -57,6 +59,10 @@ public:
     return static_cast<ConcreteType *>(this)->visitUnhandledComb(op, args...);
   }
 
+  ResultType visitVariadicComb(Operation *op, ExtraArgs... args) {
+    return static_cast<ConcreteType *>(this)->visitUnhandledComb(op, args...);
+  }
+
 #define HANDLE(OPTYPE, OPKIND)                                                 \
   ResultType visitComb(OPTYPE op, ExtraArgs... args) {                         \
     return static_cast<ConcreteType *>(this)->visit##OPKIND##Comb(op,          \
@@ -72,9 +78,10 @@ public:
   HANDLE(MulOp, Binary);
   HANDLE(DivOp, Binary);
   HANDLE(ModOp, Binary);
-  HANDLE(AndOp, Binary);
-  HANDLE(OrOp, Binary);
-  HANDLE(XorOp, Binary);
+
+  HANDLE(AndOp, Variadic);
+  HANDLE(OrOp, Variadic);
+  HANDLE(XorOp, Variadic);
 
   HANDLE(AndROp, Unary);
   HANDLE(OrROp, Unary);

--- a/lib/Dialect/FIRRTL/LowerToRTL.cpp
+++ b/lib/Dialect/FIRRTL/LowerToRTL.cpp
@@ -164,6 +164,38 @@ static LogicalResult lower(firrtl::CatPrimOp op, ArrayRef<Value> operands,
 }
 
 //===----------------------------------------------------------------------===//
+// Variadic Bitwise Operations
+//===----------------------------------------------------------------------===//
+
+template <typename OpType, typename ResultOpType>
+static LogicalResult lowerVariadicOp(OpType op, ArrayRef<Value> operands,
+                                     ConversionPatternRewriter &rewriter) {
+  auto lhs = mapAndExtendInt(operands[0], op.getType(), op, rewriter);
+  auto rhs = mapAndExtendInt(operands[1], op.getType(), op, rewriter);
+
+  if (!lhs || !rhs)
+    return failure();
+
+  rewriter.replaceOpWithNewOp<ResultOpType>(op, ValueRange({lhs, rhs}));
+  return success();
+}
+
+static LogicalResult lower(firrtl::AndPrimOp op, ArrayRef<Value> operands,
+                           ConversionPatternRewriter &rewriter) {
+  return lowerVariadicOp<firrtl::AndPrimOp, rtl::AndOp>(op, operands, rewriter);
+}
+
+static LogicalResult lower(firrtl::OrPrimOp op, ArrayRef<Value> operands,
+                           ConversionPatternRewriter &rewriter) {
+  return lowerVariadicOp<firrtl::OrPrimOp, rtl::OrOp>(op, operands, rewriter);
+}
+
+static LogicalResult lower(firrtl::XorPrimOp op, ArrayRef<Value> operands,
+                           ConversionPatternRewriter &rewriter) {
+  return lowerVariadicOp<firrtl::XorPrimOp, rtl::XorOp>(op, operands, rewriter);
+}
+
+//===----------------------------------------------------------------------===//
 // Binary Operations
 //===----------------------------------------------------------------------===//
 
@@ -189,11 +221,6 @@ static LogicalResult lower(firrtl::AddPrimOp op, ArrayRef<Value> operands,
 static LogicalResult lower(firrtl::SubPrimOp op, ArrayRef<Value> operands,
                            ConversionPatternRewriter &rewriter) {
   return lowerBinOp<firrtl::SubPrimOp, rtl::SubOp>(op, operands, rewriter);
-}
-
-static LogicalResult lower(firrtl::XorPrimOp op, ArrayRef<Value> operands,
-                           ConversionPatternRewriter &rewriter) {
-  return lowerBinOp<firrtl::XorPrimOp, rtl::XorOp>(op, operands, rewriter);
 }
 
 namespace {

--- a/test/EmitVerilog/verilog-rtl-dialect.mlir
+++ b/test/EmitVerilog/verilog-rtl-dialect.mlir
@@ -49,4 +49,29 @@ firrtl.circuit "Circuit" {
   // CHECK-NEXT:    assign foo = y;
   // CHECK-NEXT:    assign z = foo;
   // CHECK-NEXT:  endmodule
+
+  firrtl.module @M3(%x : !firrtl.uint<8>,
+                    %y : !firrtl.flip<uint<8>>,
+                    %z : i8) {
+    %c42 = rtl.constant (42 : i8) : i8
+    %c5 = rtl.constant (5 : i8) : i8
+    %a = rtl.add %z, %c42 : i8
+    %v1 = rtl.and %a, %c42, %c5 : i8
+    %v2 = rtl.xor %a, %v1, %c42 : i8
+    %v3 = rtl.or %a, %v1, %v2 : i8
+
+    %c = firrtl.stdIntCast %v3 : (i8) -> !firrtl.uint<8>
+    firrtl.connect %y, %c : !firrtl.flip<uint<8>>, !firrtl.uint<8>
+  }
+
+  // CHECK-LABEL: module M3(
+  // CHECK-NEXT:  input  [7:0] x,
+  // CHECK-NEXT:  output [7:0] y,
+  // CHECK-NEXT:  input  [7:0] z);
+  // CHECK-EMPTY:
+  // CHECK-NEXT:  wire [7:0] _T = z + 8'h2A;
+  // CHECK-NEXT:  wire [7:0] _T_0 = ( _T ) & ( 8'h2A ) & ( 8'h5 );
+  // CHECK-NEXT:  assign y = ( _T ) | ( _T_0 ) | ( ( _T ) ^ ( _T_0 ) ^ ( 8'h2A ) );
+  // CHECK-NEXT:endmodule
+
 }

--- a/test/rtl/bitwise.mlir
+++ b/test/rtl/bitwise.mlir
@@ -1,0 +1,16 @@
+// RUN: circt-opt %s | FileCheck %s
+
+// CHECK-LABEL: func @bitwise(%arg0: i7, %arg1: i7) -> i21 {
+func @bitwise(%a: i7, %b: i7) -> i21 {
+// CHECK-NEXT:    %0 = rtl.and %arg0, %arg1 : i7
+// CHECK-NEXT:    %1 = rtl.or  %arg0, %arg1 : i7
+// CHECK-NEXT:    %2 = rtl.xor %arg0, %arg1 : i7
+  %and1 = rtl.and %a, %b : i7
+  %or1  = rtl.or  %a, %b : i7
+  %xor1 = rtl.xor %a, %b : i7
+
+// CHECK-NEXT:    %[[RESULT:.*]] = rtl.concat %0, %1, %2 : (i7, i7, i7) -> i21
+// CHECK-NEXT:    return %[[RESULT]] : i21
+  %result = rtl.concat %and1, %or1, %xor1 : (i7, i7, i7) -> i21
+  return %result : i21
+}


### PR DESCRIPTION
* towards #10; initial VariRTLOp, UTVariRTLOp class
* rename Vary -> Variadic
* Add working test
* Add change to RTL dialect for variadic ops
* Make variadic ops Variadic
* Remove iostream debugging artifact
* mark commutative variadic ops Commutative
* Add suport for variadic ops, contingent on LLVM update.
* Fix format
* emit verilog for variadic
* Use interleave, parenthesize subexpressions
* Add variadic test cases

Co-authored-by: Amalee Wilson <amalee@cs.stanford.edu>